### PR TITLE
Migrate to OCamlMakefile, fix file corruption issue, support Mac OS X build.

### DIFF
--- a/debian/patches/0010-migrate-to-OCamlMakefile.patch
+++ b/debian/patches/0010-migrate-to-OCamlMakefile.patch
@@ -1,0 +1,1450 @@
+From: Jason Penney <jpenney@jczorkmid.net>
+Date: Thu, 7 Jan 2016 13:23:06 -0500
+Subject: migrate to OCamlMakefile
+
+---
+ Makefile      |   47 +++
+ OCamlMakefile | 1299 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ makefile      |   73 ----
+ 3 files changed, 1346 insertions(+), 73 deletions(-)
+ create mode 100644 Makefile
+ create mode 100644 OCamlMakefile
+ delete mode 100644 makefile
+
+diff --git a/Makefile b/Makefile
+new file mode 100644
+index 0000000..fcbcac7
+--- /dev/null
++++ b/Makefile
+@@ -0,0 +1,47 @@
++SOURCES=ptr.ml ptr-c.c crc.ml list2.ml expandarray.ml c_part.c \
++	unicode.ml unicode-c.c threadpool.ml types.ml p.ml pack.ml \
++	mp3read.ml mp3write.ml mp3info.ml mp3framehuffman-c.c \
++	mp3framehuffman.ml mp3frameutils-c.c mp3frameutils.ml mp3queue.ml \
++	mp3packer.ml
++RESULT=mp3packer
++THREADS=yes
++
++SYSTEM := $(shell ocamlc -config 2>/dev/null | grep system | sed 's/system: //')
++
++ifeq ($(SYSTEM),$(filter $(SYSTEM),mingw mingw64))
++  MINGW=1
++endif
++ifeq ($(SYSTEM),win32)
++  MSVC=1
++endif
++ifeq ($(SYSTEM),macosx)
++  MACOSX=1
++endif
++
++ARCH := $(shell ocamlc -config 2>/dev/null | grep architecture | sed 's/architecture: //')
++
++CFLAGS=-O2
++LIBS=threads str
++
++ifeq ($(SYSTEM),win32)
++	LIBS := $(LIBS) unix Shell32.lib
++else
++	ifneq (, $(shell which ocamlopt.opt))
++		OCAMLOPT=ocamlopt.opt
++	endif # ifneq (, $(shell which ocamlopt.opt))
++	ifeq ($(ARCH), amd64)
++		CFLAGS := $(CFLAGS) -mfpmath=sse -msse4.1
++		ifeq ($(SYSTEM),macosx)
++			CFLAGS := $(CFLAGS) -arch x86_64
++		endif # ifeq ($(SYSTEM),macosx)
++	endif # ifeq ($(ARCH), amd64)
++endif # ifneq ($(SYSTEM),win32)
++
++
++
++
++	
++
++all: nc
++
++-include OCamlMakefile
+diff --git a/OCamlMakefile b/OCamlMakefile
+new file mode 100644
+index 0000000..43dc3e2
+--- /dev/null
++++ b/OCamlMakefile
+@@ -0,0 +1,1299 @@
++###########################################################################
++#                              OCamlMakefile
++#                  Copyright (C) 1999-  Markus Mottl
++#
++#                             For updates see:
++#                http://www.ocaml.info/home/ocaml_sources.html
++#
++###########################################################################
++
++# Modified by damien for .glade.ml compilation
++
++# Set these variables to the names of the sources to be processed and
++# the result variable. Order matters during linkage!
++
++ifndef SOURCES
++  SOURCES := foo.ml
++endif
++export SOURCES
++
++ifndef RES_CLIB_SUF
++  RES_CLIB_SUF := _stubs
++endif
++export RES_CLIB_SUF
++
++ifndef RESULT
++  RESULT := foo
++endif
++export RESULT := $(strip $(RESULT))
++
++export LIB_PACK_NAME
++
++ifndef DOC_FILES
++  DOC_FILES := $(filter %.mli, $(SOURCES))
++endif
++export DOC_FILES
++FIRST_DOC_FILE := $(firstword $(DOC_FILES))
++
++export BCSUFFIX
++export NCSUFFIX
++
++ifndef TOPSUFFIX
++  TOPSUFFIX := .top
++endif
++export TOPSUFFIX
++
++# Eventually set include- and library-paths, libraries to link,
++# additional compilation-, link- and ocamlyacc-flags
++# Path- and library information needs not be written with "-I" and such...
++# Define THREADS if you need it, otherwise leave it unset (same for
++# USE_CAMLP4)!
++
++export THREADS
++export VMTHREADS
++export ANNOTATE
++export USE_CAMLP4
++
++export INCDIRS
++export LIBDIRS
++export EXTLIBDIRS
++export RESULTDEPS
++export OCAML_DEFAULT_DIRS
++
++export LIBS
++export CLIBS
++export CFRAMEWORKS
++
++export OCAMLFLAGS
++export OCAMLNCFLAGS
++export OCAMLBCFLAGS
++
++export OCAMLLDFLAGS
++export OCAMLNLDFLAGS
++export OCAMLBLDFLAGS
++
++export OCAMLMKLIB_FLAGS
++
++ifndef OCAMLCPFLAGS
++  OCAMLCPFLAGS := a
++endif
++export OCAMLCPFLAGS
++
++ifndef DOC_DIR
++  DOC_DIR := doc
++endif
++export DOC_DIR
++
++export PPFLAGS
++
++export LFLAGS
++export YFLAGS
++export IDLFLAGS
++
++export OCAMLDOCFLAGS
++
++export OCAMLFIND_INSTFLAGS
++
++export DVIPSFLAGS
++
++export STATIC
++
++# Add a list of optional trash files that should be deleted by "make clean"
++export TRASH
++
++ECHO := echo
++
++ifdef REALLY_QUIET
++  export REALLY_QUIET
++  ECHO := true
++  LFLAGS := $(LFLAGS) -q
++  YFLAGS := $(YFLAGS) -q
++endif
++
++####################  variables depending on your OCaml-installation
++
++SYSTEM := $(shell ocamlc -config 2>/dev/null | grep system | sed 's/system: //')
++    # This may be
++    # - mingw
++    # - mingw64
++    # - win32
++    # - cygwin
++    # - some other string means Unix
++    # - empty means ocamlc does not support -config
++
++ifeq ($(SYSTEM),$(filter $(SYSTEM),mingw mingw64))
++  MINGW=1
++endif
++ifeq ($(SYSTEM),win32)
++  MSVC=1
++endif
++
++ifdef MINGW
++  export MINGW
++  WIN32 := 1
++  # The default value 'cc' makes 'ocamlc -cc "cc"' raises the error 'The
++  # NTVDM CPU has encountered an illegal instruction'.
++  ifndef CC
++    MNO_CYGWIN := $(shell gcc -Wextra -v --help 2>/dev/null | grep -q '\-mno-cygwin'; echo $$?)
++    CC := gcc
++  else
++    MNO_CYGWIN := $(shell $$CC -Wextra -v --help 2>/dev/null | grep -q '\-mno-cygwin'; echo $$?)
++  endif
++  # We are compiling with cygwin tools:
++  ifeq ($(MNO_CYGWIN),0)
++	CFLAGS_WIN32 := -mno-cygwin
++  endif
++  # The OCaml C header files use this flag:
++  CFLAGS += -D__MINGW32__
++endif
++ifdef MSVC
++  export MSVC
++  WIN32   := 1
++  ifndef STATIC
++    CPPFLAGS_WIN32 := -DCAML_DLL
++  endif
++  CFLAGS_WIN32 += -nologo
++  EXT_OBJ := obj
++  EXT_LIB := lib
++  ifeq ($(CC),gcc)
++    # work around GNU Make default value
++    ifdef THREADS
++      CC := cl -MT
++    else
++      CC := cl
++    endif
++  endif
++  ifeq ($(CXX),g++)
++    # work around GNU Make default value
++    CXX := $(CC)
++  endif
++  CFLAG_O := -Fo
++endif
++ifdef WIN32
++  EXT_CXX := cpp
++  EXE     := .exe
++endif
++
++ifndef EXT_OBJ
++  EXT_OBJ := o
++endif
++ifndef EXT_LIB
++  EXT_LIB := a
++endif
++ifndef EXT_CXX
++  EXT_CXX := cc
++endif
++ifndef EXE
++  EXE := # empty
++endif
++ifndef CFLAG_O
++  CFLAG_O := -o # do not delete this comment (preserves trailing whitespace)!
++endif
++
++export CC
++export CXX
++export CFLAGS
++export CXXFLAGS
++export LDFLAGS
++export CPPFLAGS
++
++ifndef RPATH_FLAG
++  ifdef ELF_RPATH_FLAG
++    RPATH_FLAG := $(ELF_RPATH_FLAG)
++  else
++    RPATH_FLAG := -R
++  endif
++endif
++export RPATH_FLAG
++
++ifndef MSVC
++ifndef PIC_CFLAGS
++  PIC_CFLAGS := -fPIC
++endif
++ifndef PIC_CPPFLAGS
++  PIC_CPPFLAGS := -DPIC
++endif
++endif
++
++export PIC_CFLAGS
++export PIC_CPPFLAGS
++
++BCRESULT  := $(addsuffix $(BCSUFFIX), $(RESULT))
++NCRESULT  := $(addsuffix $(NCSUFFIX), $(RESULT))
++TOPRESULT := $(addsuffix $(TOPSUFFIX), $(RESULT))
++
++ifndef OCAMLFIND
++  OCAMLFIND := ocamlfind
++endif
++export OCAMLFIND
++
++ifndef OCAML
++  OCAML := ocaml
++endif
++export OCAML
++
++ifndef OCAMLC
++  OCAMLC := ocamlc
++endif
++export OCAMLC
++
++ifndef OCAMLOPT
++  OCAMLOPT := ocamlopt
++endif
++export OCAMLOPT
++
++ifndef OCAMLMKTOP
++  OCAMLMKTOP := ocamlmktop
++endif
++export OCAMLMKTOP
++
++ifndef OCAMLCP
++  OCAMLCP := ocamlcp
++endif
++export OCAMLCP
++
++ifndef OCAMLDEP
++  OCAMLDEP := ocamldep
++endif
++export OCAMLDEP
++
++ifndef OCAMLLEX
++  OCAMLLEX := ocamllex
++endif
++export OCAMLLEX
++
++ifndef OCAMLYACC
++  OCAMLYACC := ocamlyacc
++endif
++export OCAMLYACC
++
++ifndef OCAMLMKLIB
++  OCAMLMKLIB := ocamlmklib
++endif
++export OCAMLMKLIB
++
++ifndef OCAML_GLADECC
++  OCAML_GLADECC := lablgladecc2
++endif
++export OCAML_GLADECC
++
++ifndef OCAML_GLADECC_FLAGS
++  OCAML_GLADECC_FLAGS :=
++endif
++export OCAML_GLADECC_FLAGS
++
++ifndef CAMELEON_REPORT
++  CAMELEON_REPORT := report
++endif
++export CAMELEON_REPORT
++
++ifndef CAMELEON_REPORT_FLAGS
++  CAMELEON_REPORT_FLAGS :=
++endif
++export CAMELEON_REPORT_FLAGS
++
++ifndef CAMELEON_ZOGGY
++  CAMELEON_ZOGGY := camlp4o pa_zog.cma pr_o.cmo
++endif
++export CAMELEON_ZOGGY
++
++ifndef CAMELEON_ZOGGY_FLAGS
++  CAMELEON_ZOGGY_FLAGS :=
++endif
++export CAMELEON_ZOGGY_FLAGS
++
++ifndef OXRIDL
++  OXRIDL := oxridl
++endif
++export OXRIDL
++
++ifndef CAMLIDL
++  CAMLIDL := camlidl
++endif
++export CAMLIDL
++
++ifndef CAMLIDLDLL
++  CAMLIDLDLL := camlidldll
++endif
++export CAMLIDLDLL
++
++ifndef NOIDLHEADER
++  MAYBE_IDL_HEADER := -header
++endif
++export NOIDLHEADER
++
++export NO_CUSTOM
++
++ifndef CAMLP4
++  CAMLP4 := camlp4
++endif
++export CAMLP4
++
++ifndef REAL_OCAMLFIND
++  ifdef PACKS
++    ifndef CREATE_LIB
++      ifdef THREADS
++	PACKS += threads
++      endif
++    endif
++    empty :=
++    space := $(empty) $(empty)
++    comma := ,
++    ifdef PREDS
++      PRE_OCAML_FIND_PREDICATES := $(subst $(space),$(comma),$(PREDS))
++      PRE_OCAML_FIND_PACKAGES := $(subst $(space),$(comma),$(PACKS))
++      OCAML_FIND_PREDICATES := -predicates $(PRE_OCAML_FIND_PREDICATES)
++  #    OCAML_DEP_PREDICATES := -syntax $(PRE_OCAML_FIND_PREDICATES)
++      OCAML_FIND_PACKAGES := $(OCAML_FIND_PREDICATES) -package $(PRE_OCAML_FIND_PACKAGES)
++      OCAML_DEP_PACKAGES := $(OCAML_DEP_PREDICATES) -package $(PRE_OCAML_FIND_PACKAGES)
++    else
++      OCAML_FIND_PACKAGES := -package $(subst $(space),$(comma),$(PACKS))
++      OCAML_DEP_PACKAGES :=
++    endif
++    OCAML_FIND_LINKPKG := -linkpkg
++    REAL_OCAMLFIND := $(OCAMLFIND)
++  endif
++endif
++
++export OCAML_FIND_PACKAGES
++export OCAML_DEP_PACKAGES
++export OCAML_FIND_LINKPKG
++export REAL_OCAMLFIND
++
++ifndef OCAMLDOC
++  OCAMLDOC := ocamldoc
++endif
++export OCAMLDOC
++
++ifndef LATEX
++  LATEX := latex
++endif
++export LATEX
++
++ifndef DVIPS
++  DVIPS := dvips
++endif
++export DVIPS
++
++ifndef PS2PDF
++  PS2PDF := ps2pdf
++endif
++export PS2PDF
++
++ifndef OCAMLMAKEFILE
++  OCAMLMAKEFILE := OCamlMakefile
++endif
++export OCAMLMAKEFILE
++
++ifndef OCAMLLIBPATH
++  OCAMLLIBPATH := \
++    $(shell $(OCAMLC) 2>/dev/null -where || echo /usr/local/lib/ocaml)
++endif
++export OCAMLLIBPATH
++
++ifndef OCAML_LIB_INSTALL
++  OCAML_LIB_INSTALL := $(OCAMLLIBPATH)/contrib
++endif
++export OCAML_LIB_INSTALL
++
++###########################################################################
++
++####################  change following sections only if
++####################    you know what you are doing!
++
++# delete target files when a build command fails
++.PHONY: .DELETE_ON_ERROR
++.DELETE_ON_ERROR:
++
++# for pedants using "--warn-undefined-variables"
++export MAYBE_IDL
++export REAL_RESULT
++export CAMLIDLFLAGS
++export THREAD_FLAG
++export RES_CLIB
++export MAKEDLL
++export ANNOT_FLAG
++export C_OXRIDL
++export SUBPROJS
++export CFLAGS_WIN32
++export CPPFLAGS_WIN32
++
++INCFLAGS :=
++
++SHELL := /bin/sh
++
++MLDEPDIR := ._d
++BCDIDIR  := ._bcdi
++NCDIDIR  := ._ncdi
++
++FILTER_EXTNS := %.mli %.ml %.mll %.mly %.idl %.oxridl %.c %.m %.$(EXT_CXX) %.rep %.zog %.glade
++
++FILTERED     := $(filter $(FILTER_EXTNS), $(SOURCES))
++SOURCE_DIRS  := $(filter-out ./, $(sort $(dir $(FILTERED))))
++
++FILTERED_REP := $(filter %.rep, $(FILTERED))
++DEP_REP      := $(FILTERED_REP:%.rep=$(MLDEPDIR)/%.d)
++AUTO_REP     := $(FILTERED_REP:.rep=.ml)
++
++FILTERED_ZOG := $(filter %.zog, $(FILTERED))
++DEP_ZOG      := $(FILTERED_ZOG:%.zog=$(MLDEPDIR)/%.d)
++AUTO_ZOG     := $(FILTERED_ZOG:.zog=.ml)
++
++FILTERED_GLADE := $(filter %.glade, $(FILTERED))
++DEP_GLADE      := $(FILTERED_GLADE:%.glade=$(MLDEPDIR)/%.d)
++AUTO_GLADE     := $(FILTERED_GLADE:.glade=.ml)
++
++FILTERED_ML  := $(filter %.ml, $(FILTERED))
++DEP_ML       := $(FILTERED_ML:%.ml=$(MLDEPDIR)/%.d)
++
++FILTERED_MLI := $(filter %.mli, $(FILTERED))
++DEP_MLI      := $(FILTERED_MLI:.mli=.di)
++
++FILTERED_MLL := $(filter %.mll, $(FILTERED))
++DEP_MLL      := $(FILTERED_MLL:%.mll=$(MLDEPDIR)/%.d)
++AUTO_MLL     := $(FILTERED_MLL:.mll=.ml)
++
++FILTERED_MLY := $(filter %.mly, $(FILTERED))
++DEP_MLY      := $(FILTERED_MLY:%.mly=$(MLDEPDIR)/%.d) $(FILTERED_MLY:.mly=.di)
++AUTO_MLY     := $(FILTERED_MLY:.mly=.mli) $(FILTERED_MLY:.mly=.ml)
++
++FILTERED_IDL := $(filter %.idl, $(FILTERED))
++DEP_IDL      := $(FILTERED_IDL:%.idl=$(MLDEPDIR)/%.d) $(FILTERED_IDL:.idl=.di)
++C_IDL        := $(FILTERED_IDL:%.idl=%_stubs.c)
++ifndef NOIDLHEADER
++ C_IDL += $(FILTERED_IDL:.idl=.h)
++endif
++OBJ_C_IDL    := $(FILTERED_IDL:%.idl=%_stubs.$(EXT_OBJ))
++AUTO_IDL     := $(FILTERED_IDL:.idl=.mli) $(FILTERED_IDL:.idl=.ml) $(C_IDL)
++
++FILTERED_OXRIDL := $(filter %.oxridl, $(FILTERED))
++DEP_OXRIDL      := $(FILTERED_OXRIDL:%.oxridl=$(MLDEPDIR)/%.d) $(FILTERED_OXRIDL:.oxridl=.di)
++AUTO_OXRIDL     := $(FILTERED_OXRIDL:.oxridl=.mli) $(FILTERED_OXRIDL:.oxridl=.ml) $(C_OXRIDL)
++
++FILTERED_C_CXX := $(filter %.c %.m %.$(EXT_CXX), $(FILTERED))
++OBJ_C_CXX      := $(FILTERED_C_CXX:.c=.$(EXT_OBJ))
++OBJ_C_CXX      := $(OBJ_C_CXX:.m=.$(EXT_OBJ))
++OBJ_C_CXX      := $(OBJ_C_CXX:.$(EXT_CXX)=.$(EXT_OBJ))
++
++PRE_TARGETS  += $(AUTO_MLL) $(AUTO_MLY) $(AUTO_IDL) $(AUTO_OXRIDL) $(AUTO_ZOG) $(AUTO_REP) $(AUTO_GLADE)
++
++ALL_DEPS     := $(DEP_ML) $(DEP_MLI) $(DEP_MLL) $(DEP_MLY) $(DEP_IDL) $(DEP_OXRIDL) $(DEP_ZOG) $(DEP_REP) $(DEP_GLADE)
++
++MLDEPS       := $(filter %.d, $(ALL_DEPS))
++MLIDEPS      := $(filter %.di, $(ALL_DEPS))
++BCDEPIS      := $(MLIDEPS:%.di=$(BCDIDIR)/%.di)
++NCDEPIS      := $(MLIDEPS:%.di=$(NCDIDIR)/%.di)
++
++ALLML        := $(filter %.mli %.ml %.mll %.mly %.idl %.oxridl %.rep %.zog %.glade, $(FILTERED))
++
++IMPLO_INTF   := $(ALLML:%.mli=%.mli.__)
++IMPLO_INTF   := $(foreach file, $(IMPLO_INTF), \
++                  $(basename $(file)).cmi $(basename $(file)).cmo)
++IMPLO_INTF   := $(filter-out %.mli.cmo, $(IMPLO_INTF))
++IMPLO_INTF   := $(IMPLO_INTF:%.mli.cmi=%.cmi)
++
++IMPLX_INTF   := $(IMPLO_INTF:.cmo=.cmx)
++
++INTF         := $(filter %.cmi, $(IMPLO_INTF))
++IMPL_CMO     := $(filter %.cmo, $(IMPLO_INTF))
++IMPL_CMX     := $(IMPL_CMO:.cmo=.cmx)
++IMPL_ASM     := $(IMPL_CMO:.cmo=.asm)
++IMPL_S       := $(IMPL_CMO:.cmo=.s)
++
++OBJ_LINK     := $(OBJ_C_IDL) $(OBJ_C_CXX)
++OBJ_FILES    := $(IMPL_CMO:.cmo=.$(EXT_OBJ)) $(OBJ_LINK)
++
++EXECS        := $(addsuffix $(EXE), \
++                            $(sort $(TOPRESULT) $(BCRESULT) $(NCRESULT)))
++ifdef WIN32
++  EXECS      += $(BCRESULT).dll $(NCRESULT).dll
++endif
++
++CLIB_BASE    := $(RESULT)$(RES_CLIB_SUF)
++ifneq ($(strip $(OBJ_LINK)),)
++  RES_CLIB     := lib$(CLIB_BASE).$(EXT_LIB)
++endif
++
++ifdef WIN32
++DLLSONAME := dll$(CLIB_BASE).dll
++else
++DLLSONAME := dll$(CLIB_BASE).so
++endif
++
++NONEXECS     := $(INTF) $(IMPL_CMO) $(IMPL_CMX) $(IMPL_ASM) $(IMPL_S) \
++		$(OBJ_FILES) $(PRE_TARGETS) $(BCRESULT).cma $(NCRESULT).cmxa \
++		$(NCRESULT).$(EXT_LIB) $(BCRESULT).cmi $(BCRESULT).cmo \
++		$(NCRESULT).cmi $(NCRESULT).cmx $(NCRESULT).$(EXT_OBJ) \
++		$(RES_CLIB) $(IMPL_CMO:.cmo=.annot) \
++		$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmo $(LIB_PACK_NAME).cmx \
++		$(LIB_PACK_NAME).$(EXT_OBJ)
++
++ifndef STATIC
++  NONEXECS += $(DLLSONAME)
++endif
++
++ifndef LIBINSTALL_FILES
++  LIBINSTALL_FILES := $(RESULT).mli $(RESULT).cmi $(RESULT).cma \
++		      $(RESULT).cmxa $(RESULT).$(EXT_LIB) $(RES_CLIB)
++  ifndef STATIC
++    ifneq ($(strip $(OBJ_LINK)),)
++      LIBINSTALL_FILES += $(DLLSONAME)
++    endif
++  endif
++endif
++
++export LIBINSTALL_FILES
++
++ifdef WIN32
++  # some extra stuff is created while linking DLLs
++  NONEXECS   += $(BCRESULT).$(EXT_LIB) $(BCRESULT).exp $(NCRESULT).exp $(CLIB_BASE).exp $(CLIB_BASE).lib
++endif
++
++TARGETS      := $(EXECS) $(NONEXECS)
++
++# If there are IDL-files
++ifneq ($(strip $(FILTERED_IDL)),)
++  MAYBE_IDL := -cclib -lcamlidl
++endif
++
++ifdef USE_CAMLP4
++  CAMLP4PATH := \
++    $(shell $(CAMLP4) -where 2>/dev/null || echo /usr/local/lib/camlp4)
++  INCFLAGS := -I $(CAMLP4PATH)
++  CINCFLAGS := -I$(CAMLP4PATH)
++endif
++
++INCFLAGS := $(INCFLAGS) $(INCDIRS:%=-I %) $(SOURCE_DIRS:%=-I %) $(OCAML_DEFAULT_DIRS:%=-I %)
++CINCFLAGS += $(SOURCE_DIRS:%=-I%) $(INCDIRS:%=-I%) $(OCAML_DEFAULT_DIRS:%=-I%)
++
++ifndef MSVC
++  CLIBFLAGS += $(SOURCE_DIRS:%=-L%) $(LIBDIRS:%=-L%) \
++               $(EXTLIBDIRS:%=-L%) $(OCAML_DEFAULT_DIRS:%=-L%)
++
++  ifeq ($(ELF_RPATH), yes)
++    CLIBFLAGS += $(EXTLIBDIRS:%=-Wl,$(RPATH_FLAG)%)
++  endif
++endif
++
++ifndef PROFILING
++  INTF_OCAMLC := $(OCAMLC)
++else
++  ifndef THREADS
++    INTF_OCAMLC := $(OCAMLCP) -p $(OCAMLCPFLAGS)
++  else
++    # OCaml does not support profiling byte code
++    # with threads (yet), therefore we force an error.
++    ifndef REAL_OCAMLC
++      $(error Profiling of multithreaded byte code not yet supported by OCaml)
++    endif
++    INTF_OCAMLC := $(OCAMLC)
++  endif
++endif
++
++ifndef MSVC
++  COMMON_LDFLAGS := $(LDFLAGS:%=-ccopt %) $(SOURCE_DIRS:%=-ccopt -L%) \
++		    $(LIBDIRS:%=-ccopt -L%) $(EXTLIBDIRS:%=-ccopt -L%) \
++		    $(EXTLIBDIRS:%=-ccopt -Wl $(OCAML_DEFAULT_DIRS:%=-ccopt -L%))
++
++  ifeq ($(ELF_RPATH),yes)
++    COMMON_LDFLAGS += $(EXTLIBDIRS:%=-ccopt -Wl,$(RPATH_FLAG)%)
++  endif
++else
++  COMMON_LDFLAGS := -ccopt "/link -NODEFAULTLIB:LIBC $(LDFLAGS:%=%) $(SOURCE_DIRS:%=-LIBPATH:%) \
++		    $(LIBDIRS:%=-LIBPATH:%) $(EXTLIBDIRS:%=-LIBPATH:%) \
++		    $(OCAML_DEFAULT_DIRS:%=-LIBPATH:%) "
++endif
++
++CLIBS_OPTS := $(CLIBS:%=-cclib -l%) $(CFRAMEWORKS:%=-cclib '-framework %')
++ifdef MSVC
++  ifndef STATIC
++  # MSVC libraries do not have 'lib' prefix
++  CLIBS_OPTS := $(CLIBS:%=-cclib %.lib)
++  endif
++endif
++
++ifneq ($(strip $(OBJ_LINK)),)
++  ifdef CREATE_LIB
++    OBJS_LIBS := -cclib -l$(CLIB_BASE) $(CLIBS_OPTS) $(MAYBE_IDL)
++  else
++    OBJS_LIBS := $(OBJ_LINK) $(CLIBS_OPTS) $(MAYBE_IDL)
++  endif
++else
++  OBJS_LIBS := $(CLIBS_OPTS) $(MAYBE_IDL)
++endif
++
++ifdef LIB_PACK_NAME
++  FOR_PACK_NAME := $(shell echo $(LIB_PACK_NAME) | awk '{print toupper(substr($$0,1,1))substr($$0,2)}')
++endif
++
++# If we have to make byte-code
++ifndef REAL_OCAMLC
++  BYTE_OCAML := y
++
++  # EXTRADEPS is added dependencies we have to insert for all
++  # executable files we generate.  Ideally it should be all of the
++  # libraries we use, but it's hard to find the ones that get searched on
++  # the path since I don't know the paths built into the compiler, so
++  # just include the ones with slashes in their names.
++  EXTRADEPS := $(addsuffix .cma,$(foreach i,$(LIBS),$(if $(findstring /,$(i)),$(i))))
++
++
++  ifndef LIB_PACK_NAME
++    SPECIAL_OCAMLFLAGS := $(OCAMLBCFLAGS)
++  else
++    SPECIAL_OCAMLFLAGS := -for-pack $(FOR_PACK_NAME) $(OCAMLBCFLAGS)
++  endif
++
++  REAL_OCAMLC := $(INTF_OCAMLC)
++
++  REAL_IMPL := $(IMPL_CMO)
++  REAL_IMPL_INTF := $(IMPLO_INTF)
++  IMPL_SUF := .cmo
++
++  DEPFLAGS  :=
++  MAKE_DEPS := $(MLDEPS) $(BCDEPIS)
++
++  ifdef CREATE_LIB
++    override CFLAGS := $(PIC_CFLAGS) $(CFLAGS)
++    override CPPFLAGS := $(PIC_CPPFLAGS) $(CPPFLAGS)
++    ifndef STATIC
++      ifneq ($(strip $(OBJ_LINK)),)
++	MAKEDLL := $(DLLSONAME)
++	ALL_LDFLAGS := -dllib $(DLLSONAME)
++      endif
++    endif
++  endif
++
++  ifndef NO_CUSTOM
++    ifneq "$(strip $(OBJ_LINK) $(THREADS) $(MAYBE_IDL) $(CLIBS) $(CFRAMEWORKS))" ""
++      ALL_LDFLAGS += -custom
++    endif
++  endif
++
++  ALL_LDFLAGS += $(INCFLAGS) $(OCAMLLDFLAGS) $(OCAMLBLDFLAGS) \
++                 $(COMMON_LDFLAGS) $(LIBS:%=%.cma)
++  CAMLIDLDLLFLAGS :=
++
++  ifdef THREADS
++    ifdef VMTHREADS
++      THREAD_FLAG := -vmthread
++    else
++      THREAD_FLAG := -thread
++    endif
++    ALL_LDFLAGS := $(THREAD_FLAG) $(ALL_LDFLAGS)
++    ifndef CREATE_LIB
++      ifndef REAL_OCAMLFIND
++        ALL_LDFLAGS := unix.cma threads.cma $(ALL_LDFLAGS)
++      endif
++    endif
++  endif
++
++# we have to make native-code
++else
++  EXTRADEPS := $(addsuffix .cmxa,$(foreach i,$(LIBS),$(if $(findstring /,$(i)),$(i))))
++  ifndef PROFILING
++    SPECIAL_OCAMLFLAGS := $(OCAMLNCFLAGS)
++    PLDFLAGS :=
++  else
++    SPECIAL_OCAMLFLAGS := -p $(OCAMLNCFLAGS)
++    PLDFLAGS := -p
++  endif
++
++  ifndef LIB_PACK_NAME
++    SPECIAL_OCAMLFLAGS := $(OCAMLNCFLAGS)
++  else
++    SPECIAL_OCAMLFLAGS := -for-pack $(FOR_PACK_NAME) $(OCAMLNCFLAGS)
++  endif
++  REAL_IMPL := $(IMPL_CMX)
++  REAL_IMPL_INTF := $(IMPLX_INTF)
++  IMPL_SUF := .cmx
++
++  override CPPFLAGS := -DNATIVE_CODE $(CPPFLAGS)
++
++  DEPFLAGS  := -native
++  MAKE_DEPS := $(MLDEPS) $(NCDEPIS)
++
++  ALL_LDFLAGS := $(PLDFLAGS) $(INCFLAGS) $(OCAMLLDFLAGS) \
++                 $(OCAMLNLDFLAGS) $(COMMON_LDFLAGS)
++  CAMLIDLDLLFLAGS := -opt
++
++  ifndef CREATE_LIB
++    ALL_LDFLAGS += $(LIBS:%=%.cmxa)
++  else
++    override CFLAGS := $(PIC_CFLAGS) $(CFLAGS)
++    override CPPFLAGS := $(PIC_CPPFLAGS) $(CPPFLAGS)
++  endif
++
++  ifdef THREADS
++    THREAD_FLAG := -thread
++    ALL_LDFLAGS := $(THREAD_FLAG) $(ALL_LDFLAGS)
++    ifndef CREATE_LIB
++      ifndef REAL_OCAMLFIND
++        ALL_LDFLAGS := unix.cmxa threads.cmxa $(ALL_LDFLAGS)
++      endif
++    endif
++  endif
++endif
++
++export MAKE_DEPS
++
++ifdef ANNOTATE
++  ANNOT_FLAG := -annot
++else
++endif
++
++ALL_OCAMLCFLAGS := $(THREAD_FLAG) $(ANNOT_FLAG) $(OCAMLFLAGS) \
++                   $(INCFLAGS) $(SPECIAL_OCAMLFLAGS)
++
++ifdef make_deps
++  -include $(MAKE_DEPS)
++  PRE_TARGETS :=
++endif
++
++###########################################################################
++# USER RULES
++
++# Call "OCamlMakefile QUIET=" to get rid of all of the @'s.
++QUIET=@
++
++# generates byte-code (default)
++byte-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes
++bc:	byte-code
++
++byte-code-nolink:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes
++bcnl:	byte-code-nolink
++
++top:			$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(TOPRESULT) \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes
++
++# generates native-code
++
++native-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				make_deps=yes
++nc:	native-code
++
++native-code-nolink:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				make_deps=yes
++ncnl:	native-code-nolink
++
++# generates byte-code libraries
++byte-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(BCRESULT).cma \
++				REAL_RESULT="$(BCRESULT)" \
++				CREATE_LIB=yes \
++				make_deps=yes
++bcl:	byte-code-library
++
++# generates native-code libraries
++native-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(NCRESULT).cmxa \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				CREATE_LIB=yes \
++				make_deps=yes
++ncl:	native-code-library
++
++ifdef WIN32
++# generates byte-code dll
++byte-code-dll:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(BCRESULT).dll \
++				REAL_RESULT="$(BCRESULT)" \
++				make_deps=yes
++bcd:	byte-code-dll
++
++# generates native-code dll
++native-code-dll:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(NCRESULT).dll \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				make_deps=yes
++ncd:	native-code-dll
++endif
++
++# generates byte-code with debugging information
++debug-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dc:	debug-code
++
++debug-code-nolink:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dcnl:	debug-code-nolink
++
++# generates byte-code with debugging information (native code)
++debug-native-code:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
++				REAL_RESULT="$(NCRESULT)" make_deps=yes \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dnc:	debug-native-code
++
++debug-native-code-nolink:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) nolink \
++				REAL_RESULT="$(NCRESULT)" make_deps=yes \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dncnl:	debug-native-code-nolink
++
++# generates byte-code libraries with debugging information
++debug-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(BCRESULT).cma \
++				REAL_RESULT="$(BCRESULT)" make_deps=yes \
++				CREATE_LIB=yes \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dcl:	debug-code-library
++
++# generates byte-code libraries with debugging information (native code)
++debug-native-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(NCRESULT).cmxa \
++				REAL_RESULT="$(NCRESULT)" make_deps=yes \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				CREATE_LIB=yes \
++				OCAMLFLAGS="-g $(OCAMLFLAGS)" \
++				OCAMLLDFLAGS="-g $(OCAMLLDFLAGS)"
++dncl:	debug-native-code-library
++
++# generates byte-code for profiling
++profiling-byte-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT) \
++				REAL_RESULT="$(BCRESULT)" PROFILING="y" \
++				make_deps=yes
++pbc:	profiling-byte-code
++
++# generates native-code
++
++profiling-native-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(NCRESULT) \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				PROFILING="y" \
++				make_deps=yes
++pnc:	profiling-native-code
++
++# generates byte-code libraries
++profiling-byte-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(BCRESULT).cma \
++				REAL_RESULT="$(BCRESULT)" PROFILING="y" \
++				CREATE_LIB=yes \
++				make_deps=yes
++pbcl:	profiling-byte-code-library
++
++# generates native-code libraries
++profiling-native-code-library:	$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(RES_CLIB) $(NCRESULT).cmxa \
++				REAL_RESULT="$(NCRESULT)" PROFILING="y" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				CREATE_LIB=yes \
++				make_deps=yes
++pncl:	profiling-native-code-library
++
++# packs byte-code objects
++pack-byte-code:			$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) $(BCRESULT).cmo \
++				REAL_RESULT="$(BCRESULT)" \
++				PACK_LIB=yes make_deps=yes
++pabc:	pack-byte-code
++
++# packs native-code objects
++pack-native-code:		$(PRE_TARGETS)
++			$(QUIET)$(MAKE) -r -f $(OCAMLMAKEFILE) \
++				$(NCRESULT).cmx $(NCRESULT).$(EXT_OBJ) \
++				REAL_RESULT="$(NCRESULT)" \
++				REAL_OCAMLC="$(OCAMLOPT)" \
++				PACK_LIB=yes make_deps=yes
++panc:	pack-native-code
++
++# generates HTML-documentation
++htdoc:	$(DOC_DIR)/$(RESULT)/html/index.html
++
++# generates Latex-documentation
++ladoc:	$(DOC_DIR)/$(RESULT)/latex/doc.tex
++
++# generates PostScript-documentation
++psdoc:	$(DOC_DIR)/$(RESULT)/latex/doc.ps
++
++# generates PDF-documentation
++pdfdoc:	$(DOC_DIR)/$(RESULT)/latex/doc.pdf
++
++# generates all supported forms of documentation
++doc: htdoc ladoc psdoc pdfdoc
++
++###########################################################################
++# LOW LEVEL RULES
++
++$(REAL_RESULT):		$(REAL_IMPL_INTF) $(OBJ_LINK) $(EXTRADEPS) $(RESULTDEPS)
++			$(REAL_OCAMLFIND) $(REAL_OCAMLC) \
++				$(OCAML_FIND_PACKAGES) $(OCAML_FIND_LINKPKG) \
++				$(OBJS_LIBS) $(ALL_LDFLAGS) -o $@$(EXE) \
++				$(REAL_IMPL)
++
++nolink:			$(REAL_IMPL_INTF) $(OBJ_LINK)
++
++ifdef WIN32
++$(REAL_RESULT).dll:	$(REAL_IMPL_INTF) $(OBJ_LINK)
++			$(CAMLIDLDLL) $(CAMLIDLDLLFLAGS) $(OBJ_LINK) $(CLIBS) \
++				-o $@ $(REAL_IMPL)
++endif
++
++%$(TOPSUFFIX):		$(REAL_IMPL_INTF) $(OBJ_LINK) $(EXTRADEPS)
++			$(REAL_OCAMLFIND) $(OCAMLMKTOP) \
++				$(OCAML_FIND_PACKAGES) $(OCAML_FIND_LINKPKG) \
++				$(OBJS_LIBS) $(ALL_LDFLAGS) -o $@$(EXE) \
++				$(REAL_IMPL)
++
++.SUFFIXES:		.mli .ml .cmi .cmo .cmx .cma .cmxa .$(EXT_OBJ) \
++                        .mly .di .d .$(EXT_LIB) .idl %.oxridl .c .m .$(EXT_CXX) .h .so \
++                        .rep .zog .glade
++
++ifndef STATIC
++ifdef MINGW
++# From OCaml 3.11.0, ocamlmklib is available on windows
++OCAMLMLIB_EXISTS = $(shell which $(OCAMLMKLIB))
++ifeq ($(strip $(OCAMLMLIB_EXISTS)),)
++$(DLLSONAME):		$(OBJ_LINK)
++			$(CC) $(CFLAGS) $(CFLAGS_WIN32) $(OBJ_LINK) -shared -o $@ \
++			$(wildcard $(foreach dir,$(LIBDIRS),$(CLIBS:%=$(dir)/lib%.a))) \
++			 '$(OCAMLLIBPATH)/ocamlrun.a' \
++			-Wl,--whole-archive \
++			-Wl,--export-all-symbols \
++			-Wl,--allow-multiple-definition \
++			-Wl,--enable-auto-import
++else
++$(DLLSONAME):		$(OBJ_LINK)
++			$(OCAMLMKLIB) $(INCFLAGS) $(CLIBFLAGS) \
++				-o $(CLIB_BASE) $(OBJ_LINK) $(CLIBS:%=-l%) \
++				$(CFRAMEWORKS:%=-framework %) \
++				$(OCAMLMKLIB_FLAGS)
++endif
++else
++ifdef MSVC
++$(DLLSONAME):		$(OBJ_LINK)
++			link /NOLOGO /DLL /OUT:$@ $(OBJ_LINK) \
++			 $(wildcard $(foreach dir,$(LIBDIRS),$(CLIBS:%=$(dir)/%.lib))) \
++			 '$(OCAMLLIBPATH)/ocamlrun.lib'
++
++else
++$(DLLSONAME):		$(OBJ_LINK)
++			$(OCAMLMKLIB) $(INCFLAGS) $(CLIBFLAGS) \
++				-o $(CLIB_BASE) $(OBJ_LINK) $(CLIBS:%=-l%) $(CFRAMEWORKS:%=-framework %) \
++				$(OCAMLMKLIB_FLAGS)
++endif
++endif
++endif
++
++ifndef LIB_PACK_NAME
++$(RESULT).cma:		$(REAL_IMPL_INTF) $(MAKEDLL) $(EXTRADEPS) $(RESULTDEPS)
++			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(REAL_IMPL)
++
++$(RESULT).cmxa $(RESULT).$(EXT_LIB):	$(REAL_IMPL_INTF) $(EXTRADEPS) $(RESULTDEPS)
++			$(REAL_OCAMLFIND) $(OCAMLOPT) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(REAL_IMPL)
++else
++# Packing a bytecode library
++LIB_PACK_NAME_MLI = $(wildcard $(LIB_PACK_NAME).mli)
++ifeq ($(LIB_PACK_NAME_MLI),)
++LIB_PACK_NAME_CMI = $(LIB_PACK_NAME).cmi
++else
++# $(LIB_PACK_NAME).mli exists, it likely depends on other compiled interfaces
++LIB_PACK_NAME_CMI =
++$(LIB_PACK_NAME).cmi: $(REAL_IMPL_INTF)
++endif
++ifdef BYTE_OCAML
++$(LIB_PACK_NAME_CMI) $(LIB_PACK_NAME).cmo: $(REAL_IMPL_INTF)
++			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -pack -o $(LIB_PACK_NAME).cmo $(OCAMLLDFLAGS) $(REAL_IMPL)
++# Packing into a unit which can be transformed into a library
++# Remember the .ml's must have been compiled with -for-pack $(LIB_PACK_NAME)
++else
++$(LIB_PACK_NAME_CMI) $(LIB_PACK_NAME).cmx: $(REAL_IMPL_INTF)
++			$(REAL_OCAMLFIND) $(OCAMLOPT) -pack -o $(LIB_PACK_NAME).cmx  $(OCAMLLDFLAGS) $(REAL_IMPL)
++endif
++
++$(RESULT).cma:		$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmo $(MAKEDLL) $(EXTRADEPS) $(RESULTDEPS)
++			$(REAL_OCAMLFIND) $(REAL_OCAMLC) -a $(OBJS_LIBS) $(ALL_LDFLAGS) -o $@ $(LIB_PACK_NAME).cmo
++
++$(RESULT).cmxa $(RESULT).$(EXT_LIB):	$(LIB_PACK_NAME).cmi $(LIB_PACK_NAME).cmx $(EXTRADEPS) $(RESULTDEPS)
++			$(REAL_OCAMLFIND) $(OCAMLOPT) -a $(OBJS_LIBS) $(filter-out -custom, $(ALL_LDFLAGS)) -o $@ $(LIB_PACK_NAME).cmx
++endif
++
++$(RES_CLIB): 		$(OBJ_LINK)
++ifndef MSVC
++  ifneq ($(strip $(OBJ_LINK)),)
++		      $(AR) rcs $@ $(OBJ_LINK)
++  endif
++else
++  ifneq ($(strip $(OBJ_LINK)),)
++			lib -nologo -debugtype:cv -out:$(RES_CLIB) $(OBJ_LINK)
++  endif
++endif
++
++%.cmi:	%.mli $(EXTRADEPS)
++			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
++			if [ -z "$$pp" ]; then \
++			  $(ECHO) $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c $(THREAD_FLAG) $(ANNOT_FLAG) \
++				$(OCAMLFLAGS) $(INCFLAGS) $<; \
++			  $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c $(THREAD_FLAG) $(ANNOT_FLAG) \
++				$(OCAMLFLAGS) $(INCFLAGS) $<; \
++			else \
++			    $(ECHO) $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c -pp \"$$pp $(PPFLAGS)\" $(THREAD_FLAG) $(ANNOT_FLAG) \
++				$(OCAMLFLAGS) $(INCFLAGS) $<; \
++			    $(REAL_OCAMLFIND) $(INTF_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c -pp "$$pp $(PPFLAGS)" $(THREAD_FLAG) $(ANNOT_FLAG) \
++				$(OCAMLFLAGS) $(INCFLAGS) $<; \
++			fi
++
++%.cmi: %$(IMPL_SUF);
++
++%$(IMPL_SUF) %.$(EXT_OBJ):	%.ml $(EXTRADEPS)
++			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
++			if [ -z "$$pp" ]; then \
++			  $(ECHO) $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c $(ALL_OCAMLCFLAGS) $<; \
++			  $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c $(ALL_OCAMLCFLAGS) $<; \
++			else \
++			  $(ECHO) $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c -pp \"$$pp $(PPFLAGS)\" $(ALL_OCAMLCFLAGS) $<; \
++			  $(REAL_OCAMLFIND) $(REAL_OCAMLC) $(OCAML_FIND_PACKAGES) \
++				-c -pp "$$pp $(PPFLAGS)" $(ALL_OCAMLCFLAGS) $<; \
++			fi
++
++.PRECIOUS:		%.ml
++%.ml:			%.mll
++			$(OCAMLLEX) $(LFLAGS) $<
++
++.PRECIOUS:              %.ml %.mli
++%.ml %.mli:             %.mly
++			$(OCAMLYACC) $(YFLAGS) $<
++			$(QUIET)pp=`sed -n -e 's/.*(\*pp \([^*]*\) \*).*/\1/p;q' $<`; \
++			if [ ! -z "$$pp" ]; then \
++			  mv $*.ml $*.ml.temporary; \
++			  echo "(*pp $$pp $(PPFLAGS)*)" > $*.ml; \
++			  cat $*.ml.temporary >> $*.ml; \
++			  rm $*.ml.temporary; \
++			  mv $*.mli $*.mli.temporary; \
++			  echo "(*pp $$pp $(PPFLAGS)*)" > $*.mli; \
++			  cat $*.mli.temporary >> $*.mli; \
++			  rm $*.mli.temporary; \
++			fi
++
++
++.PRECIOUS:		%.ml
++%.ml:			%.rep
++			$(CAMELEON_REPORT) $(CAMELEON_REPORT_FLAGS) -gen $<
++
++.PRECIOUS:		%.ml
++%.ml:			%.zog
++			$(CAMELEON_ZOGGY)  $(CAMELEON_ZOGGY_FLAGS) -impl $< > $@
++
++.PRECIOUS:		%.ml
++%.ml:			%.glade
++			$(OCAML_GLADECC)  $(OCAML_GLADECC_FLAGS) $< > $@
++
++.PRECIOUS:		%.ml %.mli
++%.ml %.mli:		%.oxridl
++			$(OXRIDL) $<
++
++.PRECIOUS:		%.ml %.mli %_stubs.c %.h
++%.ml %.mli %_stubs.c %.h:		%.idl
++			$(CAMLIDL) $(MAYBE_IDL_HEADER) $(IDLFLAGS) \
++				$(CAMLIDLFLAGS) $<
++			$(QUIET)if [ $(NOIDLHEADER) ]; then touch $*.h; fi
++
++%.$(EXT_OBJ):	%.c
++			$(OCAMLC) -c -cc "$(CC)" -ccopt "$(CFLAGS) \
++				$(CPPFLAGS) $(CPPFLAGS_WIN32) \
++				$(CFLAGS_WIN32) $(CINCFLAGS) $(CFLAG_O)$@ " $<
++
++%.$(EXT_OBJ):	%.m
++			$(CC) -c $(CFLAGS) $(CINCFLAGS) $(CPPFLAGS) \
++				-I'$(OCAMLLIBPATH)' \
++				$< $(CFLAG_O)$@
++
++%.$(EXT_OBJ): %.$(EXT_CXX)
++			$(CXX) -c $(CXXFLAGS) $(CINCFLAGS) $(CPPFLAGS) \
++				-I'$(OCAMLLIBPATH)' \
++				$< $(CFLAG_O)$@
++
++$(MLDEPDIR)/%.d:	%.ml
++			$(QUIET)if [ ! -d $(@D) ]; then mkdir -p $(@D); fi
++			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
++			if [ -z "$$pp" ]; then \
++			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
++				$(INCFLAGS) $< \> $@; \
++			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
++				$(INCFLAGS) $< > $@; \
++			else \
++			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
++				-pp \"$$pp $(PPFLAGS)\" $(INCFLAGS) $< \> $@; \
++			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(OCAML_DEP_PACKAGES) \
++				-pp "$$pp $(PPFLAGS)" $(INCFLAGS) $< > $@; \
++			fi
++
++$(BCDIDIR)/%.di $(NCDIDIR)/%.di:	%.mli
++			$(QUIET)if [ ! -d $(@D) ]; then mkdir -p $(@D); fi
++			$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $<`; \
++			if [ -z "$$pp" ]; then \
++			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) $(INCFLAGS) $< \> $@; \
++			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) $(INCFLAGS) $< > $@; \
++			else \
++			  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) \
++			    -pp \"$$pp $(PPFLAGS)\" $(INCFLAGS) $< \> $@; \
++			  $(REAL_OCAMLFIND) $(OCAMLDEP) $(DEPFLAGS) \
++			    -pp "$$pp $(PPFLAGS)" $(INCFLAGS) $< > $@; \
++			fi
++
++$(DOC_DIR)/$(RESULT)/html:
++	mkdir -p $@
++
++$(DOC_DIR)/$(RESULT)/html/index.html: $(DOC_DIR)/$(RESULT)/html $(DOC_FILES)
++	rm -rf $</*
++	$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $(FIRST_DOC_FILE)`; \
++	if [ -z "$$pp" ]; then \
++	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -html -d $< $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES); \
++	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -html -d $< $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES); \
++	else \
++	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp \"$$pp $(PPFLAGS)\" -html -d $< $(OCAMLDOCFLAGS) \
++	  	$(INCFLAGS) $(DOC_FILES); \
++	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp "$$pp $(PPFLAGS)" -html -d $< $(OCAMLDOCFLAGS) \
++	  	$(INCFLAGS) $(DOC_FILES); \
++	fi
++
++$(DOC_DIR)/$(RESULT)/latex:
++	mkdir -p $@
++
++$(DOC_DIR)/$(RESULT)/latex/doc.tex: $(DOC_DIR)/$(RESULT)/latex $(DOC_FILES)
++	rm -rf $</*
++	$(QUIET)pp=`sed -n -e '/^#/d' -e 's/(\*pp \([^*]*\) \*)/\1/p;q' $(FIRST_DOC_FILE)`; \
++	if [ -z "$$pp" ]; then \
++	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -latex $(OCAMLDOCFLAGS) $(INCFLAGS) \
++	  	$(DOC_FILES) -o $@; \
++	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -latex $(OCAMLDOCFLAGS) $(INCFLAGS) $(DOC_FILES) \
++	  	-o $@; \
++	else \
++	  $(ECHO) $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp \"$$pp $(PPFLAGS)\" -latex $(OCAMLDOCFLAGS) \
++	  	$(INCFLAGS) $(DOC_FILES) -o $@; \
++	  $(REAL_OCAMLFIND) $(OCAMLDOC) $(OCAML_FIND_PACKAGES) -pp "$$pp $(PPFLAGS)" -latex $(OCAMLDOCFLAGS) \
++	  	$(INCFLAGS) $(DOC_FILES) -o $@; \
++	fi
++
++$(DOC_DIR)/$(RESULT)/latex/doc.ps: $(DOC_DIR)/$(RESULT)/latex/doc.tex
++	cd $(DOC_DIR)/$(RESULT)/latex && \
++	  $(LATEX) doc.tex && \
++	  $(LATEX) doc.tex && \
++	  $(DVIPS) $(DVIPSFLAGS) doc.dvi -o $(@F)
++
++$(DOC_DIR)/$(RESULT)/latex/doc.pdf: $(DOC_DIR)/$(RESULT)/latex/doc.ps
++	cd $(DOC_DIR)/$(RESULT)/latex && $(PS2PDF) $(<F)
++
++define make_subproj
++.PHONY:
++subproj_$(1):
++	$$(eval $$(call PROJ_$(1)))
++	$(QUIET)if [ "$(SUBTARGET)" != "all" ]; then \
++	  $(MAKE) -f $(OCAMLMAKEFILE) $(SUBTARGET); \
++	fi
++endef
++
++$(foreach subproj,$(SUBPROJS),$(eval $(call make_subproj,$(subproj))))
++
++.PHONY:
++subprojs: $(SUBPROJS:%=subproj_%)
++
++###########################################################################
++# (UN)INSTALL RULES FOR LIBRARIES
++
++.PHONY: libinstall
++libinstall:	all
++	$(QUIET)printf "\nInstalling library with ocamlfind\n"
++	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META $(LIBINSTALL_FILES)
++	$(QUIET)printf "\nInstallation successful.\n"
++
++.PHONY: libinstall-byte-code
++libinstall-byte-code:	all
++	$(QUIET)printf "\nInstalling byte-code library with ocamlfind\n"
++	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META \
++	  $(filter-out $(RESULT).$(EXT_LIB) $(RESULT).cmxa, $(LIBINSTALL_FILES))
++	$(QUIET)printf "\nInstallation successful.\n"
++
++.PHONY: libinstall-native-code
++libinstall-native-code:	all
++	$(QUIET)printf "\nInstalling native-code library with ocamlfind\n"
++	$(OCAMLFIND) install $(OCAMLFIND_INSTFLAGS) $(RESULT) META \
++	  $(filter-out $(DLLSONAME) $(RESULT).cma, $(LIBINSTALL_FILES))
++	$(QUIET)printf "\nInstallation successful.\n"
++
++.PHONY: libuninstall
++libuninstall:
++	$(QUIET)printf "\nUninstalling library with ocamlfind\n"
++	$(OCAMLFIND) remove $(OCAMLFIND_INSTFLAGS) $(RESULT)
++	$(QUIET)printf "\nUninstallation successful.\n"
++
++.PHONY: rawinstall
++rawinstall:	all
++	$(QUIET)printf "\nInstalling library to: $(OCAML_LIB_INSTALL)\n"
++	-install -d $(OCAML_LIB_INSTALL)
++	for i in $(LIBINSTALL_FILES); do \
++	  if [ -f $$i ]; then \
++	    install -c -m 0644 $$i $(OCAML_LIB_INSTALL); \
++	  fi; \
++	done
++	$(QUIET)printf "\nInstallation successful.\n"
++
++.PHONY: rawuninstall
++rawuninstall:
++	$(QUIET)printf "\nUninstalling library from: $(OCAML_LIB_INSTALL)\n"
++	cd $(OCAML_LIB_INSTALL) && rm $(notdir $(LIBINSTALL_FILES))
++	$(QUIET)printf "\nUninstallation successful.\n"
++
++###########################################################################
++# MAINTENANCE RULES
++
++.PHONY:	clean
++clean::
++	rm -f $(TARGETS) $(TRASH)
++	rm -rf $(BCDIDIR) $(NCDIDIR) $(MLDEPDIR)
++
++.PHONY:	cleanup
++cleanup::
++	rm -f $(NONEXECS) $(TRASH)
++	rm -rf $(BCDIDIR) $(NCDIDIR) $(MLDEPDIR)
++
++.PHONY: clean-doc
++clean-doc::
++	rm -rf $(DOC_DIR)/$(RESULT)
++
++.PHONY: clean-all
++clean-all:: clean clean-doc
++
++.PHONY: nobackup
++nobackup:
++	rm -f *.bak *~ *.dup
+diff --git a/makefile b/makefile
+deleted file mode 100644
+index 3461270..0000000
+--- a/makefile
++++ /dev/null
+@@ -1,73 +0,0 @@
+-ifdef ComSpec
+-	#Windows
+-	O=.obj
+-	EXE=.exe
+-	EXLIBRARIES=Shell32.lib
+-	SSEOPT=
+-else
+-	#Other
+-	O=.o
+-	EXE=
+-	EXLIBRARIES=
+-	SSEOPT=-ccopt "-msse4.1"
+-endif
+-
+-
+-#common=-w "+a-4-9-32-35" -warn-error "+a-4-6-7-9-27-29-32..39" -warn-error "+a-4-9-32-35" $(SSEOPT) -thread unix.cmxa threads.cmxa str.cmxa $(EXLIBRARIES)
+-common=$(SSEOPT) -thread unix.cmxa threads.cmxa str.cmxa $(EXLIBRARIES)
+-
+-ocaml=ocamlopt.opt $(common)
+-
+-
+-all: depend mp3packer
+-
+-
+-.SUFFIXES: .ml .mli .cmo .cmi .cmx $O
+-
+-.ml.cmx:
+-	$(ocaml) -c $<
+-
+-.mli.cmi:
+-	$(ocaml) -c $<
+-
+-ifdef ComSpec
+-.c$O:
+-	$(ocaml) -ccopt "/Fa$@.asm" -c $<
+-else
+-.c$O:
+-	$(ocaml) -ccopt "-save-temps" -c $<
+-endif
+-
+-
+-ALLREQS=ptr.cmx ptr-c$O crc.cmx list2.cmx expandarray.cmx c_part$O unicode.cmx unicode-c$O threadpool.cmx types.cmx p.cmx pack.cmx mp3read.cmx mp3write.cmx mp3info.cmx mp3framehuffman-c$O mp3framehuffman.cmx mp3frameutils-c$O mp3frameutils.cmx mp3queue.cmx
+-
+-
+-
+-MP3PACKER=$(ALLREQS) mp3packer.cmx
+-
+-mp3packer: depend $(MP3PACKER)
+-	$(ocaml) -o $@$(EXE) $(MP3PACKER)
+-
+-
+-MP3READER=$(ALLREQS) mp3reader.cmx
+-
+-mp3reader: depend $(MP3READER)
+-	$(ocaml) -o $@$(EXE) $(MP3READER)
+-
+-
+-
+-test: depend $(ALLREQS) test.cmx
+-	$(ocaml) -o $@$(EXE) $(ALLREQS) test.cmx
+-	./test$(EXE)
+-
+-
+-
+-clean:
+-	rm -f ./*$O ./*.cmi ./*.cmx ./*.cmo ./*.cma ./*.cmxa ./*.asm ./*.s ./*.i
+-
+-depend:
+-	ocamldep *.mli *.ml > .depend
+-
+--include .depend
+-
+-

--- a/debian/patches/0011-hopefully-universal-byteswap.patch
+++ b/debian/patches/0011-hopefully-universal-byteswap.patch
@@ -1,0 +1,184 @@
+From: Jason Penney <jpenney@jczorkmid.net>
+Date: Sat, 2 Jan 2016 13:25:11 -0500
+Subject: (hopefully) universal byteswap
+
+---
+ c_part.c            |  2 ++
+ mp3framehuffman-c.c | 12 +-----------
+ ptr-c.c             | 37 ++++---------------------------------
+ ptr.h               | 49 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 56 insertions(+), 44 deletions(-)
+
+diff --git a/c_part.c b/c_part.c
+index f34791e..12d01a4 100644
+--- a/c_part.c
++++ b/c_part.c
+@@ -190,6 +190,8 @@ CAMLprim value get_os_thread_self_id() {
+ //		printf("HANDLE IS %p\n", (int)dup_handle);
+ 		out_val = win_alloc_handle(dup_handle);
+ 	}
++#elif defined(__APPLE__)
++    out_val = pthread_mach_thread_np(pthread_self());
+ #else
+ 	out_val = Val_int(pthread_self());
+ #endif
+diff --git a/mp3framehuffman-c.c b/mp3framehuffman-c.c
+index 32cdb45..07b7db3 100644
+--- a/mp3framehuffman-c.c
++++ b/mp3framehuffman-c.c
+@@ -331,19 +331,9 @@ static unsigned int get_bits_slow(seq_string_t *s, int num_bits) {
+ 
+ static unsigned int get_bits_wordwise(seq_string_t *s, int num_bits) {
+ 	uint32 raw;
+-
+-#if defined(__WIN32__) && !defined __CYGWIN__
+ 	uint32 *int_ptr;
+ 	int_ptr = (uint32 *)s->byte_ptr;
+-	raw = _byteswap_ulong(*int_ptr) << s->bit_index;
+-#else
+-	raw = (
+-		(s->byte_ptr[0] << 24) |
+-		(s->byte_ptr[1] << 16) |
+-		(s->byte_ptr[2] <<  8) |
+-		(s->byte_ptr[3]      )
+-	);
+-#endif
++	raw = byteswap32(*int_ptr) << s->bit_index;
+ 	raw >>= 1;
+ 	raw >>= 31 - num_bits;
+ 
+diff --git a/ptr-c.c b/ptr-c.c
+index a80864d..ebf30df 100644
+--- a/ptr-c.c
++++ b/ptr-c.c
+@@ -18,11 +18,6 @@
+ //#define enter_blocking_section()
+ //#define leave_blocking_section()
+ 
+-#ifdef _WIN32
+-#define HAS_BYTESWAP 1
+-#endif
+-
+-
+ /*
+  * This is a new style for ptrs: the custom ptr points to a ptr_struct struct
+  */
+@@ -318,23 +313,12 @@ CAMLprim value ptr_get_float_of_64(value ptr_val, value offset_val) {
+ // Apparently CAMLparamX is only needed if a heap allocation takes place before a heap access
+ CAMLprim void ptr_put_16_of_int_bswap(value ptr_val, value offset_val, value put_val) {
+ 	uint16_t *loc = (uint16_t *)(Begin_val(ptr_val) + Long_val(offset_val));
+-	uint16_t put = Int_val(put_val);
+-	// It looks like _byteswap_ushort just maps to a 16-bit rotate, so use a more portable version
+-	// It should map the exact same way
+-	put = (((put & 0x00FF) << 8) | ((put & 0xFF00) >> 8));
+-	*loc = put;
++	*loc = byteswap16(Int_val(put_val));
+ }
+ 
+ CAMLprim void ptr_put_32_of_int_bswap(value ptr_val, value offset_val, value put_val) {
+ 	uint32 *loc = (uint32 *)(Begin_val(ptr_val) + Long_val(offset_val));
+-	uint32 put = Int_val(put_val);
+-#if HAS_BYTESWAP
+-	put = _byteswap_ulong(put);
+-#else
+-	put = (((put & 0x0000FFFF) << 16) | ((put & 0xFFFF0000) >> 16));
+-	put = (((put & 0x00FF00FF) <<  8) | ((put & 0xFF00FF00) >>  8));
+-#endif
+-	*loc = put;
++	*loc = byteswap32(Int_val(put_val));
+ }
+ 
+ // bswap only works on ints, so we have to go double -> float -> int
+@@ -342,25 +326,12 @@ CAMLprim void ptr_put_32_of_float_bswap(value ptr_val, value offset_val, value p
+ 	uint32 *loc = (uint32 *)(Begin_val(ptr_val) + Long_val(offset_val));
+ 	float put_float = Double_val(put_val);
+ 	uint32 put = *((uint32 *)(&put_float));
+-#if HAS_BYTESWAP
+-	put = _byteswap_ulong(put);
+-#else
+-	put = (((put & 0x0000FFFF) << 16) | ((put & 0xFFFF0000) >> 16));
+-	put = (((put & 0x00FF00FF) <<  8) | ((put & 0xFF00FF00) >>  8));
+-#endif
+-	*loc = put;
++	*loc = byteswap32(put);
+ }
+ 
+ CAMLprim value ptr_get_int_of_32u_bswap(value ptr_val, value offset_val) {
+ 	uint32 *loc = (uint32 *)(Begin_val(ptr_val) + Long_val(offset_val));
+-	uint32 got = loc[0];
+-#if HAS_BYTESWAP
+-	got = _byteswap_ulong(got);
+-#else
+-// GCC has __builtin_bswap32, but the assembly doesn't look too much better
+-	got = (((got & 0x0000FFFF) << 16) | ((got & 0xFFFF0000) >> 16));
+-	got = (((got & 0x00FF00FF) <<  8) | ((got & 0xFF00FF00) >>  8));
+-#endif
++	uint32 got = byteswap32(loc[0]);
+ 	return(Val_int(got));
+ }
+ 
+diff --git a/ptr.h b/ptr.h
+index ae6b024..0d1445f 100644
+--- a/ptr.h
++++ b/ptr.h
+@@ -37,6 +37,14 @@ typedef unsigned __int16 uint16_t;
+ #define TRUE 1
+ #endif
+ 
++#ifdef __linux__
++#include <byteswap.h>
++#endif
++
++#if defined(__APPLE__)
++#include <libkern/OSByteOrder.h>
++#endif
++
+ enum ptr_type {
+ 	PTR_MALLOC,
+ 	PTR_MMAP,
+@@ -108,4 +116,45 @@ static struct custom_operations generic_ptr_opts = {
+ 	custom_deserialize_default
+ };
+ 
++static inline uint32_t byteswap32(uint32_t n)
++{
++#if defined(__builtin_bswap32)
++     return __builtin_bswap32(n);
++#elif defined(OSSwapInt32)
++     return OSSwapInt32(n);
++#elif defined(bswap32)
++     return bswap32(n);
++#elif defined(__swap32)
++     return __swap32(n);
++#elif defined(bswap_32)
++     return bswap_32(n);
++#elif defined(_byteswap_ulong)
++     return _byteswap_ulong(n);
++#else 
++     return	(((n << 24) & 0xff000000 ) |
++             ((n <<  8) & 0x00ff0000 ) |
++             ((n >>  8) & 0x0000ff00 ) |
++     		 ((n >> 24) & 0x000000ff ));
++#endif
++}
++
++static inline uint16_t byteswap16(uint16_t n)
++{
++#if defined(__builtin_bswap16)
++     return __builtin_bswap16(n);
++#elif defined(OSSwapInt16)
++     return OSSwapInt16(n);
++#elif defined(bswap16)
++     return bswap16(n);
++#elif defined(__swap16)
++     return __swap16(n);
++#elif defined(bswap_16)
++     return bswap_16(n);
++#elif defined(_byteswap_ushort)
++     return _byteswap_ushort(n);
++#else
++     return (((n & 0x00FF) << 8) | ((n & 0xFF00) >> 8));
++#endif
++}
++
+ #endif /* PTR_H */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,5 @@
 0007-Makefile-Don-t-bomb-compilation-on-32-64-bits.patch
 0008-Makefile-Only-compile-mp3packer.patch
 0009-Makefile-Don-t-require-multiple-invocations-of-make.patch
+0010-migrate-to-OCamlMakefile.patch
+0011-hopefully-universal-byteswap.patch

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,5 @@
 	dh  $@
 
 override_dh_auto_configure:
-	$(MAKE) depend
 
 override_dh_auto_test:


### PR DESCRIPTION
I used  `pkg-mp3packer` to build a binary for Ubuntu 14.04, but the result was corrupting mp3 files (they still appeared to be valid files, but on playback something was obviously wrong).

I had changes locally I'd done to get mp3packer working on on Mac OS X (including replacing the custom `makefile` with [`OCamlMakefile`](https://github.com/mmottl/ocaml-makefile)).  At the time I had tried to abstract all the options for byte swapping in a pair of functions. With minor changes I was able to get that building on Ubuntu and producing identical files the Mac OS X build.  

I did my best to apply a minimal patch, since I had a number of changes similar to one you already had. I did my best to correctly work with the debian packing in `pkg-mp3packer` (although I could not get `git-buildpackage` to generate a changelog). 
